### PR TITLE
Auto publish release notes

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,37 +1,37 @@
-name: Build and Test Hope UI
+# name: Build and Test Hope UI
 
-# Controls when the action will run.
-on:
-  # Triggers the workflow on push or pull request events but only for the main branch
-  push:
-    branches: [main, develop]
-  pull_request:
-    branches: [main]
+# # Controls when the action will run.
+# on:
+#   # Triggers the workflow on push or pull request events but only for the main branch
+#   push:
+#     branches: [main, develop]
+#   pull_request:
+#     branches: [main]
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
-jobs:
-  build-test:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+# # A workflow run is made up of one or more jobs that can run sequentially or in parallel
+# jobs:
+#   build-test:
+#     # The type of runner that the job will run on
+#     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [16.x]
+#     strategy:
+#       matrix:
+#         node-version: [16.x]
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-      - uses: pnpm/action-setup@v2.0.1
-        with:
-          version: 7.0.0-rc.2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: "pnpm"
-      - name: pnpm install, build and test
-        run: |
-          pnpm install
-          pnpm build
-          pnpm test
+#     # Steps represent a sequence of tasks that will be executed as part of the job
+#     steps:
+#       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+#       - uses: actions/checkout@v2
+#       - uses: pnpm/action-setup@v2.0.1
+#         with:
+#           version: 7.0.0-rc.2
+#       - name: Use Node.js ${{ matrix.node-version }}
+#         uses: actions/setup-node@v2
+#         with:
+#           node-version: ${{ matrix.node-version }}
+#           cache: "pnpm"
+#       - name: pnpm install, build and test
+#         run: |
+#           pnpm install
+#           pnpm build
+#           pnpm test

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,37 +1,37 @@
-# name: Build and Test Hope UI
+name: Build and Test Hope UI
 
-# # Controls when the action will run.
-# on:
-#   # Triggers the workflow on push or pull request events but only for the main branch
-#   push:
-#     branches: [main, develop]
-#   pull_request:
-#     branches: [main]
+# Controls when the action will run.
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main]
 
-# # A workflow run is made up of one or more jobs that can run sequentially or in parallel
-# jobs:
-#   build-test:
-#     # The type of runner that the job will run on
-#     runs-on: ubuntu-latest
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  build-test:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
 
-#     strategy:
-#       matrix:
-#         node-version: [16.x]
+    strategy:
+      matrix:
+        node-version: [16.x]
 
-#     # Steps represent a sequence of tasks that will be executed as part of the job
-#     steps:
-#       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-#       - uses: actions/checkout@v2
-#       - uses: pnpm/action-setup@v2.0.1
-#         with:
-#           version: 7.0.0-rc.2
-#       - name: Use Node.js ${{ matrix.node-version }}
-#         uses: actions/setup-node@v2
-#         with:
-#           node-version: ${{ matrix.node-version }}
-#           cache: "pnpm"
-#       - name: pnpm install, build and test
-#         run: |
-#           pnpm install
-#           pnpm build
-#           pnpm test
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      - uses: pnpm/action-setup@v2.0.1
+        with:
+          version: 7.0.0-rc.2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "pnpm"
+      - name: pnpm install, build and test
+        run: |
+          pnpm install
+          pnpm build
+          pnpm test

--- a/.github/workflows/publish-release-notes.yml
+++ b/.github/workflows/publish-release-notes.yml
@@ -1,0 +1,15 @@
+name: Publish Release Notes Workflow
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: mangs/simple-release-notes-action@v1
+        with:
+          changelog_path: ./packages/solid/CHANGELOG.md
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          packagejson_path: ./packages/solid/package.json

--- a/.github/workflows/publish-release-notes.yml
+++ b/.github/workflows/publish-release-notes.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: mangs/simple-release-notes-action@v1
+      - uses: mangs/simple-release-notes-action@v2
         with:
           changelog_path: ./packages/solid/CHANGELOG.md
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-release-notes.yml
+++ b/.github/workflows/publish-release-notes.yml
@@ -1,7 +1,7 @@
 name: Publish Release Notes Workflow
 on:
   push:
-    branches: [auto-publish-release-notes]
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/publish-release-notes.yml
+++ b/.github/workflows/publish-release-notes.yml
@@ -1,7 +1,7 @@
 name: Publish Release Notes Workflow
 on:
   push:
-    branches: [main]
+    branches: [auto-publish-release-notes]
 
 jobs:
   build:

--- a/packages/solid/CHANGELOG.md
+++ b/packages/solid/CHANGELOG.md
@@ -1,8 +1,8 @@
-## [0.6.2-test](https://github.com/mangs/hope-ui/compare/v0.6.2...v0.6.2-test) (2022-06-05)
+## [0.6.3](https://github.com/mangs/hope-ui/compare/v0.6.2...v0.6.3) (2022-06-05)
 
 ### 🐛 Bug fixes
 
-- Testing auto-publishing release notes
+- Add [Publish Release Notes Workflow](.github/workflows/publish-release-notes.yml) to enable auto-publishing of release notes to GitHub using [mangs/simple-release-notes-action](https://github.com/mangs/simple-release-notes-action)
 
 ## [0.6.2](https://github.com/fabien-ml/hope-ui/compare/v0.6.1...v0.6.2) (2022-05-31)
 

--- a/packages/solid/CHANGELOG.md
+++ b/packages/solid/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.6.3](https://github.com/mangs/hope-ui/compare/v0.6.2...v0.6.3) (2022-06-05)
+
+### 🐛 Bug fixes
+
+- Testing auto-publishing release notes
+
 ## [0.6.2](https://github.com/fabien-ml/hope-ui/compare/v0.6.1...v0.6.2) (2022-05-31)
 
 ### 🐛 Bug fixes

--- a/packages/solid/CHANGELOG.md
+++ b/packages/solid/CHANGELOG.md
@@ -1,9 +1,3 @@
-## here's a test for version [0.6.2+test2](https://github.com/mangs/hope-ui/compare/v0.6.2...v0.6.3) (2022-06-05)
-
-### 🐛 Bug fixes
-
-- Test number 2
-
 ## [0.6.3](https://github.com/mangs/hope-ui/compare/v0.6.2...v0.6.3) (2022-06-05)
 
 ### 🐛 Bug fixes

--- a/packages/solid/CHANGELOG.md
+++ b/packages/solid/CHANGELOG.md
@@ -1,3 +1,9 @@
+## here's a test for version [0.6.2+test2](https://github.com/mangs/hope-ui/compare/v0.6.2...v0.6.3) (2022-06-05)
+
+### 🐛 Bug fixes
+
+- Test number 2
+
 ## [0.6.3](https://github.com/mangs/hope-ui/compare/v0.6.2...v0.6.3) (2022-06-05)
 
 ### 🐛 Bug fixes

--- a/packages/solid/CHANGELOG.md
+++ b/packages/solid/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.6.3](https://github.com/mangs/hope-ui/compare/v0.6.2...v0.6.3) (2022-06-05)
+## [0.6.2-test](https://github.com/mangs/hope-ui/compare/v0.6.2...v0.6.2-test) (2022-06-05)
 
 ### 🐛 Bug fixes
 

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hope-ui/solid",
-  "version": "0.6.3",
+  "version": "0.6.2+test2",
   "private": false,
   "description": "The SolidJS component library you've hoped for.",
   "keywords": [

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hope-ui/solid",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": false,
   "description": "The SolidJS component library you've hoped for.",
   "keywords": [

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hope-ui/solid",
-  "version": "0.6.2-test",
+  "version": "0.6.3",
   "private": false,
   "description": "The SolidJS component library you've hoped for.",
   "keywords": [

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hope-ui/solid",
-  "version": "0.6.2+test2",
+  "version": "0.6.3",
   "private": false,
   "description": "The SolidJS component library you've hoped for.",
   "keywords": [

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hope-ui/solid",
-  "version": "0.6.3",
+  "version": "0.6.2-test",
   "private": false,
   "description": "The SolidJS component library you've hoped for.",
   "keywords": [


### PR DESCRIPTION
Great job on this awesome project, and congratulations on winning your group for SolidHack! 😀 I'm a big SolidJS fan (I'll be at the NYC meetup this week), and I've been following this project for awhile. I left a note of support to you on GitHub a few months ago, not sure if you remember.

I wrote [a GitHub action](https://github.com/mangs/simple-release-notes-action) that I use for my team at work that automates publishing release notes to GitHub and does so with a really easy-to-use interface; checkout [the readme](https://github.com/mangs/simple-release-notes-action/blob/main/README.md) or ping me and I'll walk you through it.

Ultimately, the action finds the "section" of markdown in your changelog that matches the version number in `package.json` and creates a GitHub release; it's pretty much that simple. I looked at a lot of other actions and everything was so complicated, so I made this.

I noticed you've been manually posting release notes which is what I was doing for years before I ended up writing this action, so I hope this saves you a little time. 🍺

Here's an example of the output from my testing of this exact PR on my own fork of this repo: https://github.com/mangs/hope-ui/releases. ~~Links aren't allowed in release titles;~~ the text is taken exactly from the markdown. However, [links work fine in the release note body](https://github.com/mangs/simple-release-notes-action/releases).

~~I'm working on title parsing now so that doesn't happen. The `v2` action should automatically add that feature once I update the tag.~~

UPDATE: I published [version `2.1.0` of the action](https://github.com/mangs/simple-release-notes-action/releases/tag/v2.1.0) that fixes the links-in-titles issue, so you should be good to go. You can see examples of me testing [here](https://github.com/mangs/hope-ui/releases) via [this PR](https://github.com/mangs/hope-ui/pull/2) in my forked repo.

This should be ready to merge! 👌