### PR TITLE
feat: add breadcrumb

### DIFF
--- a/apps/docs/src/NAV_SECTIONS.ts
+++ b/apps/docs/src/NAV_SECTIONS.ts
@@ -209,6 +209,10 @@ export const NAV_SECTIONS: NavSection[] = [
         title: "Anchor",
         href: "/docs/components/anchor",
       },
+      {
+        title: "Breadcrumb",
+        href: "/docs/components/breadcrumb",
+      },
     ],
   },
   {

--- a/apps/docs/src/routes/docs/components/breadcrumb.mdx
+++ b/apps/docs/src/routes/docs/components/breadcrumb.mdx
@@ -1,6 +1,5 @@
 import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbSeparator } from "@hope-ui/core";
 import { SunIcon } from "~/components/icons";
-import { Link } from "solid-app-router";
 
 import { Preview } from "~/components/preview";
 import { VerticalWithLabelExample, WithLabelExample } from "~/examples/divider-example";

--- a/apps/docs/src/routes/docs/components/breadcrumb.mdx
+++ b/apps/docs/src/routes/docs/components/breadcrumb.mdx
@@ -1,0 +1,354 @@
+import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbSeparator } from "@hope-ui/core";
+import { SunIcon } from "~/components/icons";
+import { Link } from "solid-app-router";
+
+import { Preview } from "~/components/preview";
+import { VerticalWithLabelExample, WithLabelExample } from "~/examples/divider-example";
+
+# Breadcrumb
+
+Breadcrumbs, or a breadcrumb navigation, can help enhance how users navigate to previous page levels of a website, especially if that website has many pages or products.
+
+## Import
+
+```tsx
+import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbSeparator } from "@hope-ui/core";
+```
+
+- **Breadcrumb**: The parent container for breadcrumbs.
+- **BreadcrumbItem**: Individual breadcrumb element containing a link and separator.
+- **BreadcrumbLink**: The breadcrumb link.
+- **BreadcrumbSeparator**: The visual separator between each breadcrumb.
+
+## Usage
+
+Add the `currentPage` prop to the `BreadcrumbLink` that matches the current path. When this prop is present, the `BreadcrumbLink` renders a `span` with `aria-current` set to `page` instead of an anchor element.
+
+<Preview>
+  <Breadcrumb>
+    <BreadcrumbItem>
+      <BreadcrumbLink href="#">Home</BreadcrumbLink>
+      <BreadcrumbSeparator />
+    </BreadcrumbItem>
+    <BreadcrumbItem>
+      <BreadcrumbLink href="#">Docs</BreadcrumbLink>
+      <BreadcrumbSeparator />
+    </BreadcrumbItem>
+    <BreadcrumbItem>
+      <BreadcrumbLink currentPage>Breadcrumb</BreadcrumbLink>
+    </BreadcrumbItem>
+  </Breadcrumb>
+</Preview>
+
+```tsx
+<Breadcrumb>
+  <BreadcrumbItem>
+    <BreadcrumbLink href="#">Home</BreadcrumbLink>
+    <BreadcrumbSeparator />
+  </BreadcrumbItem>
+  <BreadcrumbItem>
+    <BreadcrumbLink href="#">Docs</BreadcrumbLink>
+    <BreadcrumbSeparator />
+  </BreadcrumbItem>
+  <BreadcrumbItem>
+    <BreadcrumbLink currentPage>Breadcrumb</BreadcrumbLink>
+  </BreadcrumbItem>
+</Breadcrumb>
+```
+
+### Breadcrumb separator
+
+Use the `separator` prop to change the separator used in the breadcrumb.
+
+<Preview>
+  <Breadcrumb separator="-">
+    <BreadcrumbItem>
+      <BreadcrumbLink href="#">Home</BreadcrumbLink>
+      <BreadcrumbSeparator />
+    </BreadcrumbItem>
+    <BreadcrumbItem>
+      <BreadcrumbLink href="#">Docs</BreadcrumbLink>
+      <BreadcrumbSeparator />
+    </BreadcrumbItem>
+    <BreadcrumbItem>
+      <BreadcrumbLink currentPage>Breadcrumb</BreadcrumbLink>
+    </BreadcrumbItem>
+  </Breadcrumb>
+</Preview>
+
+```tsx
+<Breadcrumb separator="-">
+  <BreadcrumbItem>
+    <BreadcrumbLink href="#">Home</BreadcrumbLink>
+    <BreadcrumbSeparator />
+  </BreadcrumbItem>
+  <BreadcrumbItem>
+    <BreadcrumbLink href="#">Docs</BreadcrumbLink>
+    <BreadcrumbSeparator />
+  </BreadcrumbItem>
+  <BreadcrumbItem>
+    <BreadcrumbLink currentPage>Breadcrumb</BreadcrumbLink>
+  </BreadcrumbItem>
+</Breadcrumb>
+```
+
+### Using icon as separator
+
+You can pass any JSX.Element to the separator prop.
+
+<Preview>
+  <Breadcrumb separator={<SunIcon />}>
+    <BreadcrumbItem>
+      <BreadcrumbLink href="#">Home</BreadcrumbLink>
+      <BreadcrumbSeparator />
+    </BreadcrumbItem>
+    <BreadcrumbItem>
+      <BreadcrumbLink href="#">Docs</BreadcrumbLink>
+      <BreadcrumbSeparator />
+    </BreadcrumbItem>
+    <BreadcrumbItem>
+      <BreadcrumbLink currentPage>Breadcrumb</BreadcrumbLink>
+    </BreadcrumbItem>
+  </Breadcrumb>
+</Preview>
+
+```tsx
+<Breadcrumb separator={<SunIcon />}>
+  <BreadcrumbItem>
+    <BreadcrumbLink href="#">Home</BreadcrumbLink>
+    <BreadcrumbSeparator />
+  </BreadcrumbItem>
+  <BreadcrumbItem>
+    <BreadcrumbLink href="#">Docs</BreadcrumbLink>
+    <BreadcrumbSeparator />
+  </BreadcrumbItem>
+  <BreadcrumbItem>
+    <BreadcrumbLink currentPage>Breadcrumb</BreadcrumbLink>
+  </BreadcrumbItem>
+</Breadcrumb>
+```
+
+### Separator spacing
+
+Use the `spacing` prop to apply left and right margin to each separator.
+
+<Preview>
+  <Breadcrumb spacing="$4">
+    <BreadcrumbItem>
+      <BreadcrumbLink href="#">Home</BreadcrumbLink>
+      <BreadcrumbSeparator />
+    </BreadcrumbItem>
+    <BreadcrumbItem>
+      <BreadcrumbLink href="#">Docs</BreadcrumbLink>
+      <BreadcrumbSeparator />
+    </BreadcrumbItem>
+    <BreadcrumbItem>
+      <BreadcrumbLink currentPage>Breadcrumb</BreadcrumbLink>
+    </BreadcrumbItem>
+  </Breadcrumb>
+</Preview>
+
+```tsx
+<Breadcrumb spacing="$4">
+  <BreadcrumbItem>
+    <BreadcrumbLink href="#">Home</BreadcrumbLink>
+    <BreadcrumbSeparator />
+  </BreadcrumbItem>
+  <BreadcrumbItem>
+    <BreadcrumbLink href="#">Docs</BreadcrumbLink>
+    <BreadcrumbSeparator />
+  </BreadcrumbItem>
+  <BreadcrumbItem>
+    <BreadcrumbLink currentPage>Breadcrumb</BreadcrumbLink>
+  </BreadcrumbItem>
+</Breadcrumb>
+```
+
+### Collapsed breadcrumbs
+
+<Preview>
+  <Breadcrumb separator="/" maxItem={3}>
+    <BreadcrumbItem>
+      <BreadcrumbLink href="#">Home</BreadcrumbLink>
+      <BreadcrumbSeparator />
+    </BreadcrumbItem>
+
+    <BreadcrumbItem>
+      <BreadcrumbLink href="">Docs</BreadcrumbLink>
+      <BreadcrumbSeparator />
+    </BreadcrumbItem>
+
+    <BreadcrumbItem>
+      <BreadcrumbLink href="#">Link</BreadcrumbLink>
+      <BreadcrumbSeparator />
+    </BreadcrumbItem>
+
+    <BreadcrumbItem>
+      <BreadcrumbLink href="#" currentPage>Breadcrumb</BreadcrumbLink>
+    </BreadcrumbItem>
+
+  </Breadcrumb>
+</Preview>
+
+```tsx
+<Breadcrumb separator="/" maxItem={3}>
+  <BreadcrumbItem>
+    <BreadcrumbLink href="#">Home</BreadcrumbLink>
+    <BreadcrumbSeparator />
+  </BreadcrumbItem>
+
+  <BreadcrumbItem>
+    <BreadcrumbLink href="">Docs</BreadcrumbLink>
+    <BreadcrumbSeparator />
+  </BreadcrumbItem>
+
+  <BreadcrumbItem>
+    <BreadcrumbLink href="#">Link</BreadcrumbLink>
+    <BreadcrumbSeparator />
+  </BreadcrumbItem>
+
+  <BreadcrumbItem>
+    <BreadcrumbLink href="#" currentPage>
+      Breadcrumb
+    </BreadcrumbLink>
+  </BreadcrumbItem>
+</Breadcrumb>
+```
+
+## Composition
+
+Breadcrumb composes Box so you can pass all Box props to change the style of the breadcrumbs.
+
+<Preview>
+  <Breadcrumb fontWeight="$medium" fontSize="$sm" spacing="$4">
+    <BreadcrumbItem>
+      <BreadcrumbLink href="#" _hover={{ color: "tomato" }}>
+        Home
+      </BreadcrumbLink>
+      <BreadcrumbSeparator />
+    </BreadcrumbItem>
+    <BreadcrumbItem>
+      <BreadcrumbLink href="#" _hover={{ color: "tomato" }}>
+        Docs
+      </BreadcrumbLink>
+      <BreadcrumbSeparator />
+    </BreadcrumbItem>
+    <BreadcrumbItem>
+      <BreadcrumbLink currentPage _hover={{ color: "$success10" }}>
+        Breadcrumb
+      </BreadcrumbLink>
+    </BreadcrumbItem>
+  </Breadcrumb>
+</Preview>
+
+```tsx
+<Breadcrumb fontWeight="$medium" fontSize="$sm" spacing="$4">
+  <BreadcrumbItem>
+    <BreadcrumbLink href="#" _hover={{ color: "tomato" }}>
+      Home
+    </BreadcrumbLink>
+    <BreadcrumbSeparator />
+  </BreadcrumbItem>
+  <BreadcrumbItem>
+    <BreadcrumbLink href="#" _hover={{ color: "tomato" }}>
+      Docs
+    </BreadcrumbLink>
+    <BreadcrumbSeparator />
+  </BreadcrumbItem>
+  <BreadcrumbItem>
+    <BreadcrumbLink currentPage _hover={{ color: "$success10" }}>
+      Breadcrumb
+    </BreadcrumbLink>
+  </BreadcrumbItem>
+</Breadcrumb>
+```
+
+## Usage with routing library
+
+To use the Breadcrumb with a routing Library like solid-app-router, all you need to do is to pass the as prop to the BreadcrumbLink component.
+
+<Preview>
+  <Breadcrumb>
+    <BreadcrumbItem>
+      <BreadcrumbLink href="#">Home</BreadcrumbLink>
+      <BreadcrumbSeparator />
+    </BreadcrumbItem>
+    <BreadcrumbItem>
+      <BreadcrumbLink href="#">Docs</BreadcrumbLink>
+      <BreadcrumbSeparator />
+    </BreadcrumbItem>
+    <BreadcrumbItem>
+      <BreadcrumbLink currentPage>Breadcrumb</BreadcrumbLink>
+    </BreadcrumbItem>
+  </Breadcrumb>
+</Preview>
+```tsx 
+import {Link} from "solid-app-router";
+
+<Breadcrumb>
+  <BreadcrumbItem>
+    <BreadcrumbLink as={Link} href="#">
+      Home
+    </BreadcrumbLink>
+    <BreadcrumbSeparator />
+  </BreadcrumbItem>
+  <BreadcrumbItem>
+    <BreadcrumbLink as={Link} href="#">
+      Docs
+    </BreadcrumbLink>
+    <BreadcrumbSeparator />
+  </BreadcrumbItem>
+  <BreadcrumbItem>
+    <BreadcrumbLink currentPage>Breadcrumb</BreadcrumbLink>
+  </BreadcrumbItem>
+</Breadcrumb>
+```
+
+## Accessibility
+
+- The Breadcrumbs are rendered in a nav to denote that it is a navigation landmark.
+- The Breadcrumb nav has aria-label set to breadcrumb.
+- The BreadcrumbLink with currentPage prop has aria-current set to page.
+- The separator has role set to presentation to denote that its for presentation purposes.
+
+## Theming
+
+Use the BreadcrumbTheme type to override Breadcrumb styles and default props when extending Hope UI theme.
+
+```ts
+import { extendTheme, BreadcrumbTheme } from "@hope-ui/core";
+const theme = extendTheme({
+  components: {
+    Breadcrumb: {
+      // ...overrides
+    } as BreadcrumbTheme,
+  },
+});
+```
+
+### Component parts
+
+| Name      | Static selector             | Description         |
+| --------- | --------------------------- | ------------------- |
+| root      | `hope-Breadcrumb-root`      | Root element        |
+| item      | `hope-Breadcrumb-item`      | item of Breadcrumbs |
+| link      | `hope-Breadcrumb-link`      | link of item        |
+| separator | `hope-Breadcrumb-separator` | separator of item   |
+
+## Props
+
+### Breadcrumb
+
+| Name                | Type                          | Description                                                                | Default value |
+| ------------------- | ----------------------------- | -------------------------------------------------------------------------- | ------------- |
+| spacing             | `SystemStyleGridProps["gap"]` | The left and right space applied to each separator.                        | '0.5rem       |
+| separator           | `string \| JSX.Element`       | The visual separator between each breadcrumb item.                         | '/'           |
+| maxItem             | `number`                      | Determines the maximum number of breadcrumbs displayed.                    | 5             |
+| itemsAfterCollapse  | `number`                      | If max items is exceeded, the number of items to show after the ellipsis.  | 1             |
+| itemsBeforeCollapse | `number`                      | If max items is exceeded, the number of items to show before the ellipsis. | 1             |
+
+### BreadcrumbLink
+
+| Name        | Type      | Description                                                                               | Default value |
+| ----------- | --------- | ----------------------------------------------------------------------------------------- | ------------- |
+| currentPage | `boolean` | If `true`, renders a span with `aria-current` set to `page` instead of an anchor element. | false         |

--- a/packages/core/src/breadcrumb/breadcrumb-context.ts
+++ b/packages/core/src/breadcrumb/breadcrumb-context.ts
@@ -8,7 +8,9 @@ export function useBreadcrumbContext() {
   const context = useContext(BreadcrumbContext);
 
   if (!context) {
-    throw new Error("[hope-ui]: `useButtonContext` must be used within a `Breadcrumb` component");
+    throw new Error(
+      "[hope-ui]: `useBreadcrumbContext` must be used within a `Breadcrumb` component"
+    );
   }
 
   return context;

--- a/packages/core/src/breadcrumb/breadcrumb-context.ts
+++ b/packages/core/src/breadcrumb/breadcrumb-context.ts
@@ -1,0 +1,15 @@
+import { createContext, useContext } from "solid-js";
+
+import { BreadcrumbContextValue } from "./types";
+
+export const BreadcrumbContext = createContext<BreadcrumbContextValue>();
+
+export function useBreadcrumbContext() {
+  const context = useContext(BreadcrumbContext);
+
+  if (!context) {
+    throw new Error("[hope-ui]: `useButtonContext` must be used within a `Breadcrumb` component");
+  }
+
+  return context;
+}

--- a/packages/core/src/breadcrumb/breadcrumb-item.tsx
+++ b/packages/core/src/breadcrumb/breadcrumb-item.tsx
@@ -1,0 +1,35 @@
+import { createHopeComponent, hope } from "@hope-ui/styles";
+import { splitProps } from "solid-js";
+
+import { BreadcrumbStyleConfigProps, useBreadcrumbStyleConfig } from "./breadcrumb.style";
+import { useBreadcrumbContext } from "./breadcrumb-context";
+
+export const BreadcrumbItem = createHopeComponent<"li", BreadcrumbStyleConfigProps>(props => {
+  const context = useBreadcrumbContext();
+
+  const [local, styleConfigProps, others] = splitProps(
+    props,
+    ["class", "children"],
+    ["styleConfigOverride", "unstyled"]
+  );
+
+  const { baseClasses, styleOverrides } = useBreadcrumbStyleConfig("Breadcrumb", {
+    get unstyled() {
+      return styleConfigProps.unstyled;
+    },
+    get styleConfigOverride() {
+      return styleConfigProps.styleConfigOverride;
+    },
+  });
+
+  return (
+    <hope.li
+      gap={context?.state.gap}
+      class={baseClasses().item}
+      __css={{ ...styleOverrides().item }}
+      {...others}
+    >
+      {local.children}
+    </hope.li>
+  );
+});

--- a/packages/core/src/breadcrumb/breadcrumb-link.tsx
+++ b/packages/core/src/breadcrumb/breadcrumb-link.tsx
@@ -1,0 +1,59 @@
+import { createHopeComponent, hope, mergeThemeProps } from "@hope-ui/styles";
+import clsx from "clsx";
+import { Show, splitProps } from "solid-js";
+
+import { useBreadcrumbStyleConfig } from "./breadcrumb.style";
+import { BreadcrumbLinkProps } from "./types";
+
+export const BreadcrumbLink = createHopeComponent<any, BreadcrumbLinkProps>(props => {
+  props = mergeThemeProps(
+    "BreadcrumbLink",
+    {
+      currentPage: false,
+    },
+    props
+  );
+
+  const [local, styleConfigProps, others] = splitProps(
+    props,
+    ["currentPage", "href", "class", "children"],
+    ["styleConfigOverride", "unstyled"]
+  );
+
+  const { baseClasses, styleOverrides } = useBreadcrumbStyleConfig("Breadcrumb", {
+    get currentPage() {
+      return local.currentPage;
+    },
+    get unstyled() {
+      return styleConfigProps.unstyled;
+    },
+    get styleConfigOverride() {
+      return styleConfigProps.styleConfigOverride;
+    },
+  });
+
+  return (
+    <Show
+      when={local.currentPage}
+      fallback={
+        <hope.a
+          href={local.href}
+          __css={{ ...styleOverrides().link }}
+          class={clsx(baseClasses().link, local.class)}
+          {...others}
+        >
+          {local.children}
+        </hope.a>
+      }
+    >
+      <hope.span
+        aria-current="page"
+        __css={{ ...styleOverrides().link }}
+        class={clsx(baseClasses().link, local.class)}
+        {...others}
+      >
+        {local.children}
+      </hope.span>
+    </Show>
+  );
+});

--- a/packages/core/src/breadcrumb/breadcrumb-separator.tsx
+++ b/packages/core/src/breadcrumb/breadcrumb-separator.tsx
@@ -28,6 +28,7 @@ export const BreadcrumbSeparator = createHopeComponent<"span", BreadcrumbStyleCo
       <hope.span
         class={clsx(baseClasses().separator, local.class)}
         __css={{ ...styleOverrides().separator }}
+        role="presentation"
         {...others}
       >
         {state?.state.separator}

--- a/packages/core/src/breadcrumb/breadcrumb-separator.tsx
+++ b/packages/core/src/breadcrumb/breadcrumb-separator.tsx
@@ -1,0 +1,37 @@
+import { createHopeComponent, hope } from "@hope-ui/styles";
+import clsx from "clsx";
+import { splitProps } from "solid-js";
+
+import { BreadcrumbStyleConfigProps, useBreadcrumbStyleConfig } from "./breadcrumb.style";
+import { useBreadcrumbContext } from "./breadcrumb-context";
+
+export const BreadcrumbSeparator = createHopeComponent<"span", BreadcrumbStyleConfigProps>(
+  props => {
+    const state = useBreadcrumbContext();
+
+    const [local, styleConfigProps, others] = splitProps(
+      props,
+      ["class"],
+      ["styleConfigOverride", "unstyled"]
+    );
+
+    const { baseClasses, styleOverrides } = useBreadcrumbStyleConfig("Breadcrumb", {
+      get unstyled() {
+        return styleConfigProps.unstyled;
+      },
+      get styleConfigOverride() {
+        return styleConfigProps.styleConfigOverride;
+      },
+    });
+
+    return (
+      <hope.span
+        class={clsx(baseClasses().separator, local.class)}
+        __css={{ ...styleOverrides().separator }}
+        {...others}
+      >
+        {state?.state.separator}
+      </hope.span>
+    );
+  }
+);

--- a/packages/core/src/breadcrumb/breadcrumb.style.ts
+++ b/packages/core/src/breadcrumb/breadcrumb.style.ts
@@ -1,0 +1,74 @@
+import { createStyleConfig, StyleConfigProps } from "@hope-ui/styles";
+
+type DividerParts = "root" | "list" | "item" | "link" | "separator";
+
+interface DividerVariants {
+  /** whether is the current page. */
+  currentPage: boolean;
+}
+
+export const useBreadcrumbStyleConfig = createStyleConfig<DividerParts, DividerVariants>(
+  ({ vars }) => ({
+    root: {
+      baseStyle: {
+        display: "block",
+        fontSize: vars.fontSizes.base,
+        lineHeight: vars.lineHeights[6],
+      },
+    },
+    list: {
+      baseStyle: {
+        listStyle: "none",
+        display: "flex",
+        alignItems: "center",
+        margin: "0",
+        padding: "0",
+      },
+    },
+    item: {
+      baseStyle: {
+        display: "inline-flex",
+        alignItems: "center",
+      },
+    },
+    link: {
+      baseStyle: {
+        position: "relative",
+        display: "inline-flex",
+        alignItems: "center",
+        outline: "none",
+        backgroundColor: "transparent",
+        color: vars.colors.neutral[500],
+        textDecoration: "none",
+        cursor: "pointer",
+        transition: "color 250ms ease 0s, text-decoration 250ms ease 0s",
+        _hover: {
+          color: vars.colors.primary[500],
+        },
+      },
+      variants: {
+        currentPage: {
+          true: {
+            cursor: "default",
+            color: vars.colors.neutral[900],
+            _hover: {
+              color: vars.colors.neutral[900],
+            },
+          },
+        },
+      },
+    },
+    separator: {
+      baseStyle: {
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+      },
+    },
+  }),
+  {
+    currentPage: false,
+  }
+);
+
+export type BreadcrumbStyleConfigProps = StyleConfigProps<typeof useBreadcrumbStyleConfig>;

--- a/packages/core/src/breadcrumb/breadcrumb.test.tsx
+++ b/packages/core/src/breadcrumb/breadcrumb.test.tsx
@@ -1,0 +1,55 @@
+import {
+  checkAccessibility,
+  itHasSemanticClass,
+  itIsPolymorphic,
+  itRendersChildren,
+  itSupportsClass,
+  itSupportsRef,
+  itSupportsStyle,
+} from "@hope-ui/tests";
+import { render, screen } from "solid-testing-library";
+
+import { Breadcrumb } from "./breadcrumb";
+import { BreadcrumbItem } from "./breadcrumb-item";
+import { BreadcrumbLink } from "./breadcrumb-link";
+import { BreadcrumbSeparator } from "./breadcrumb-separator";
+import { BreadcrumbProps } from "./types";
+
+const defaultProps: BreadcrumbProps = {};
+
+describe("Breadcrumb", () => {
+  checkAccessibility([
+    <Breadcrumb separator="/">
+      <BreadcrumbItem>
+        <BreadcrumbLink href="#">Home</BreadcrumbLink>
+        <BreadcrumbSeparator />
+      </BreadcrumbItem>
+    </Breadcrumb>,
+  ]);
+  itIsPolymorphic(Breadcrumb as any, defaultProps);
+  itRendersChildren(Breadcrumb as any, defaultProps);
+  itSupportsClass(Breadcrumb as any, defaultProps);
+  itHasSemanticClass(Breadcrumb as any, defaultProps, "hope-Breadcrumb-root");
+  itSupportsRef(Breadcrumb as any, defaultProps, HTMLElement); // should be `nav`, but not support.
+  itSupportsStyle(Breadcrumb as any, defaultProps);
+
+  it("breadcrumb should have attribute `aria-label=breadcrumb`.", () => {
+    render(() => <Breadcrumb data-testid="breadcrumb" />);
+
+    const breadcrumb = screen.getByTestId("breadcrumb");
+
+    expect(breadcrumb).toHaveAttribute("aria-label", "breadcrumb");
+  });
+
+  it("breadcrumbLink should have attribute `aria-current=page` when passingcurrentPage prop.", () => {
+    render(() => (
+      <BreadcrumbLink data-testid="breadcrumb" currentPage>
+        Home
+      </BreadcrumbLink>
+    ));
+
+    const breadcrumbLink = screen.getByTestId("breadcrumb");
+
+    expect(breadcrumbLink).toHaveAttribute("aria-current", "page");
+  });
+});

--- a/packages/core/src/breadcrumb/breadcrumb.tsx
+++ b/packages/core/src/breadcrumb/breadcrumb.tsx
@@ -27,13 +27,7 @@ const BreadcrumbList = createHopeComponent<"ol", BreadcrumbListProps>(props => {
   const renderWithCollapse = (resovledItems: ResolvedJSXElement[]) => {
     return [
       ...resovledItems.slice(0, props.itemsBeforeCollapse),
-      <CollapseButton
-        onClick={() => {
-          setExpandable(true);
-          console.log(expandable());
-          return {};
-        }}
-      />,
+      <CollapseButton onClick={() => setExpandable(true)} />,
       <BreadcrumbSeparator />,
       ...resovledItems.slice(
         resovledItems.length - (props?.itemsAfterCollapse || 1),

--- a/packages/core/src/breadcrumb/breadcrumb.tsx
+++ b/packages/core/src/breadcrumb/breadcrumb.tsx
@@ -1,0 +1,60 @@
+import { createHopeComponent, hope, mergeThemeProps } from "@hope-ui/styles";
+import clsx from "clsx";
+import { splitProps } from "solid-js";
+import { createStore } from "solid-js/store";
+
+import { useBreadcrumbStyleConfig } from "./breadcrumb.style";
+import { BreadcrumbContext } from "./breadcrumb-context";
+import { BreadcrumbProps } from "./types";
+
+export const Breadcrumb = createHopeComponent<"nav", BreadcrumbProps>(props => {
+  const dprops = mergeThemeProps(
+    "Breadcrumb",
+    {
+      separator: "/",
+      spacing: "0.5rem",
+    },
+    props
+  );
+
+  const [local, styleConfigProps, others] = splitProps(
+    dprops,
+    ["class", "children", "spacing", "separator"],
+    ["styleConfigOverride", "unstyled"]
+  );
+
+  const [state] = createStore({
+    get gap() {
+      return local.spacing;
+    },
+    get separator() {
+      return local.separator;
+    },
+  });
+
+  const { baseClasses, styleOverrides } = useBreadcrumbStyleConfig("Breadcrumb", {
+    get unstyled() {
+      return styleConfigProps.unstyled;
+    },
+    get styleConfigOverride() {
+      return styleConfigProps.styleConfigOverride;
+    },
+  });
+
+  const context = { state };
+
+  return (
+    <BreadcrumbContext.Provider value={context}>
+      <hope.nav
+        aria-label="breadcrumb"
+        __css={{ ...styleOverrides().root }}
+        class={clsx(baseClasses().root, local.class)}
+        {...others}
+      >
+        <hope.ol class={clsx(baseClasses().list)} gap={state.gap}>
+          {local.children}
+        </hope.ol>
+      </hope.nav>
+    </BreadcrumbContext.Provider>
+  );
+});

--- a/packages/core/src/breadcrumb/index.ts
+++ b/packages/core/src/breadcrumb/index.ts
@@ -1,0 +1,5 @@
+export * from "./breadcrumb";
+export * from "./breadcrumb-item";
+export * from "./breadcrumb-link";
+export * from "./breadcrumb-separator";
+export * from "./types";

--- a/packages/core/src/breadcrumb/types.ts
+++ b/packages/core/src/breadcrumb/types.ts
@@ -6,16 +6,36 @@ import { BreadcrumbStyleConfigProps } from "./breadcrumb.style";
 export type Separator = string | JSX.Element;
 
 export interface BreadcrumbProps extends BreadcrumbStyleConfigProps {
-  /** separator between each breadcrumb. */
+  /** Separator between each breadcrumb. */
   separator?: Separator;
 
   /** The left and right space applied to each separator */
   spacing?: SystemStyleGridProps["gap"];
+
+  /** Determines the maximum number of breadcrumbs displayed. `default: 5` */
+  maxItem?: number;
+
+  /** `default: 1` */
+  itemsAfterCollapse?: number;
+
+  /** `default: 1` */
+  itemsBeforeCollapse?: number;
 }
 
 export interface BreadcrumbLinkProps extends BreadcrumbStyleConfigProps {
   /** whether is the current page. */
   currentPage?: boolean;
+}
+
+export interface BreadcrumbListProps {
+  /** Determines the maximum number of breadcrumbs displayed. `default: 5` */
+  maxItem?: number;
+
+  /** `default: 1` */
+  itemsAfterCollapse?: number;
+
+  /** `default: 1` */
+  itemsBeforeCollapse?: number;
 }
 
 export interface BreadcrumbState {

--- a/packages/core/src/breadcrumb/types.ts
+++ b/packages/core/src/breadcrumb/types.ts
@@ -1,0 +1,28 @@
+import { SystemStyleGridProps } from "@hope-ui/styles";
+import { JSX } from "solid-js";
+
+import { BreadcrumbStyleConfigProps } from "./breadcrumb.style";
+
+export type Separator = string | JSX.Element;
+
+export interface BreadcrumbProps extends BreadcrumbStyleConfigProps {
+  /** separator between each breadcrumb. */
+  separator?: Separator;
+
+  /** The left and right space applied to each separator */
+  spacing?: SystemStyleGridProps["gap"];
+}
+
+export interface BreadcrumbLinkProps extends BreadcrumbStyleConfigProps {
+  /** whether is the current page. */
+  currentPage?: boolean;
+}
+
+export interface BreadcrumbState {
+  gap: SystemStyleGridProps["gap"];
+  separator: Separator;
+}
+
+export interface BreadcrumbContextValue {
+  state: BreadcrumbState;
+}

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -11,6 +11,7 @@ export * from "./utils";
 export * from "./anchor";
 export * from "./aspect-ratio";
 export * from "./box";
+export * from "./breadcrumb";
 export * from "./button";
 export * from "./center";
 export * from "./close-button";


### PR DESCRIPTION
## feature
+ hope-ui v0.x
+ Collapsed breadcrumb

## Example

```tsx
<Breadcrumb separator="/" maxItem={4}>
  <BreadcrumbItem>
    <BreadcrumbLink href="http://baidu.com">Baidu</BreadcrumbLink>
    <BreadcrumbSeparator />
  </BreadcrumbItem>

  <BreadcrumbItem>
    <BreadcrumbLink href="http://google.com">Google</BreadcrumbLink>
    <BreadcrumbSeparator />
  </BreadcrumbItem>

  <BreadcrumbItem>
    <BreadcrumbLink href="http://bing.com" currentPage>
      Bing
    </BreadcrumbLink>
  </BreadcrumbItem>
</Breadcrumb>
```

### screen shot

<img width="315" alt="image" src="https://user-images.githubusercontent.com/73047992/204121114-46bc403b-1197-46dd-8608-f77f9d4d1a10.png">
